### PR TITLE
feat: Add ablity to register custom route with action class for reusability

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,6 @@
 name: "Check"
 
 on:
-  pull_request:
   push:
     branches:
       - "*"

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -15,7 +15,7 @@ Use the discussion functionality and propose your idea:
 
 ## Commit messages
 
-- We are using (conventionalcommits)[https://www.conventionalcommits.org/en/v1.0.0/]
+- We are using [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/)
 - CHANGELOG.md is generated from given commits using this [action](https://github.com/requarks/changelog-action).
 - These keywords will ignore changelog change `build,docs,other,style`
 

--- a/src/Contracts/CreateCustomRouteActionContract.php
+++ b/src/Contracts/CreateCustomRouteActionContract.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Contracts;
+
+use Illuminate\Routing\RouteRegistrar;
+use LaraStrict\Entities\CustomRouteEntity;
+
+interface CreateCustomRouteActionContract
+{
+    /**
+     * Registers custom route. Returns false if no registration has been made.
+     */
+    public function execute(CustomRouteEntity $customRoute, RouteRegistrar $routeRegistrar): bool;
+}

--- a/src/Contracts/HasCustomRoutes.php
+++ b/src/Contracts/HasCustomRoutes.php
@@ -11,7 +11,7 @@ use LaraStrict\Entities\CustomRouteEntity;
 interface HasCustomRoutes
 {
     /**
-     * @return array<string|int, Closure(CustomRouteEntity,RouteRegistrar):bool|string>
+     * @return array<string|int, class-string<CreateCustomRouteActionContract>|string|Closure(CustomRouteEntity,RouteRegistrar):bool>
      */
     public function getCustomRoutes(): array;
 }

--- a/src/Testing/Providers/Concerns/AssertProviderRegistersRoutes.php
+++ b/src/Testing/Providers/Concerns/AssertProviderRegistersRoutes.php
@@ -16,7 +16,7 @@ trait AssertProviderRegistersRoutes
     /**
      * Asserts correct that routes are correctly registered in correct prefix (pluralized)
      *
-     * @param class-string<AbstractServiceProvider>                         $registerServiceProvider
+     * @param class-string<AbstractServiceProvider>                        $registerServiceProvider
      * @param array<string, array<string>|array<int, Closure(Route):void>> $expectUrlsByMethod
      * ['GET'=>['web/tests/my-api']]
      */
@@ -39,12 +39,16 @@ trait AssertProviderRegistersRoutes
         foreach ($expectUrlsByMethod as $method => $urls) {
             $registeredUrls = $routes->get($method);
 
-            $errorMessage = 'Not found in: ' . implode(', ', array_keys($registeredUrls));
+            $currentUrls = [];
+            foreach ($urls as $index => $value) {
+                $url = is_callable($value) ? $index : $value;
+                $currentUrls[] = $url;
+            }
+
+            Assert::assertEquals(array_keys($registeredUrls), $currentUrls);
 
             foreach ($urls as $index => $value) {
                 $url = is_callable($value) ? $index : $value;
-
-                Assert::assertArrayHasKey($url, $registeredUrls, $errorMessage);
 
                 if (is_callable($value)) {
                     $value($registeredUrls[$url]);

--- a/tests/Feature/Providers/AbstractServiceProviderTest.php
+++ b/tests/Feature/Providers/AbstractServiceProviderTest.php
@@ -92,6 +92,9 @@ class AbstractServiceProviderTest extends TestCase
                 'dev/with-customs/1-dev' => function (Route $route) {
                     $this->assertEquals([], $route->gatherMiddleware());
                 },
+                'custom-route/with-customs/1-custom' => function (Route $route) {
+                    $this->assertEquals([], $route->gatherMiddleware());
+                },
             ],
         ]);
     }
@@ -110,6 +113,9 @@ class AbstractServiceProviderTest extends TestCase
                     $this->assertEquals(['admin'], $route->gatherMiddleware());
                 },
                 'dev/with-alls/1-dev' => function (Route $route) {
+                    $this->assertEquals([], $route->gatherMiddleware());
+                },
+                'custom-route/with-alls/2-custom' => function (Route $route) {
                     $this->assertEquals([], $route->gatherMiddleware());
                 },
             ],

--- a/tests/Feature/Providers/WithAll/Http/routes/with_all_custom.php
+++ b/tests/Feature/Providers/WithAll/Http/routes/with_all_custom.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('2-custom', static function () {
+});

--- a/tests/Feature/Providers/WithCustom/CreateCustomRouteAction.php
+++ b/tests/Feature/Providers/WithCustom/CreateCustomRouteAction.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LaraStrict\Feature\Providers\WithCustom;
+
+use Illuminate\Routing\RouteRegistrar;
+use LaraStrict\Contracts\CreateCustomRouteActionContract;
+use LaraStrict\Entities\CustomRouteEntity;
+
+class CreateCustomRouteAction implements CreateCustomRouteActionContract
+{
+    public function execute(CustomRouteEntity $customRoute, RouteRegistrar $routeRegistrar): bool
+    {
+        $routeRegistrar
+            ->prefix('custom-route/' . $customRoute->urlPrefix)
+            ->group($customRoute->path);
+
+        return true;
+    }
+}

--- a/tests/Feature/Providers/WithCustom/Http/routes/with_custom_custom.php
+++ b/tests/Feature/Providers/WithCustom/Http/routes/with_custom_custom.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('1-custom', static function () {
+});

--- a/tests/Feature/Providers/WithCustom/WithCustomServiceProvider.php
+++ b/tests/Feature/Providers/WithCustom/WithCustomServiceProvider.php
@@ -23,6 +23,7 @@ class WithCustomServiceProvider extends AbstractServiceProvider implements HasRo
                 return true;
             },
             'testing' => static fn (): bool => false,
+            'custom' => CreateCustomRouteAction::class,
         ];
     }
 }


### PR DESCRIPTION
- Create a class in your Actions folder within your module
- Implement \LaraStrict\ContractsCreateCustomRouteActionContract
```php
public function execute(CustomRouteEntity $customRoute, RouteRegistrar $routeRegistrar): bool
    {
        $routeRegistrar
            ->prefix('custom-route/' . $customRoute->urlPrefix)
            ->group($customRoute->path);

        return true;
    }
```
- In your service provider within `getCustomRoutes` method add your class:
```php
'custom' => CreateCustomRouteAction::class,
```