### PR TITLE
fix(Database): Allow all Laravel 9 versions (Fix PHPStan warnings)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "laravel/framework": "^9.49.0",
+        "laravel/framework": "^9",
         "psr/log": "^2 | ^3"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    reportUnmatchedIgnoredErrors: true
 
     parallel:
         processTimeout: 600.0
@@ -23,4 +24,12 @@ parameters:
 
     excludePaths:
             - 'tests/Feature/Testing/Commands/MakeExpectationCommand/*.php'
+
+    ignoreErrors:
+        # CastsAttributes template was added in Laravel 9.49 (remove when we drop L9 support)
+        -
+            message: "#^PHPDoc tag @implements contains generic type Illuminate\\\\Contracts\\\\Database\\\\Eloquent\\\\CastsAttributes\\<float, float\\|int\\|string\\|null\\> but interface Illuminate\\\\Contracts\\\\Database\\\\Eloquent\\\\CastsAttributes is not generic\\.$#"
+            count: 1
+            path: src/Database/Models/Casts/FloatCast.php
+            reportUnmatched: false
 


### PR DESCRIPTION
By using reportUnmatched we can ignore ignored error on Laravel above 9.49 which adds @template support

--

@h4kuna I've fixed the PHPStan warnings on the lower laravel version using reportUnmatched - https://phpstan.org/user-guide/ignoring-errors#reporting-unused-ignores

Laravel below 9.49 is allowed for now.