### PR TITLE
feat(Testing): Improve using translations classes in your tests

### DIFF
--- a/src/Config/AbstractProviderConfig.php
+++ b/src/Config/AbstractProviderConfig.php
@@ -6,13 +6,13 @@ namespace LaraStrict\Config;
 
 use Illuminate\Config\Repository;
 use LaraStrict\Providers\AbstractServiceProvider;
-use LaraStrict\Providers\Actions\GetAppServiceProviderForClassAction;
+use LaraStrict\Providers\Contracts\GetAppServiceProviderForClassActionContract;
 
 abstract class AbstractProviderConfig extends AbstractConfig
 {
     public function __construct(
         Repository $config,
-        private readonly GetAppServiceProviderForClassAction $getAppServiceProviderForClassAction
+        private readonly GetAppServiceProviderForClassActionContract $getAppServiceProviderForClassAction
     ) {
         parent::__construct($config);
     }

--- a/src/Core/LaraStrictServiceProvider.php
+++ b/src/Core/LaraStrictServiceProvider.php
@@ -16,7 +16,9 @@ use LaraStrict\Database\DatabaseServiceProvider;
 use LaraStrict\Docker\DockerServiceProvider;
 use LaraStrict\Log\LogServiceProvider;
 use LaraStrict\Providers\AbstractBaseServiceProvider;
+use LaraStrict\Providers\Actions\GetAppServiceProviderForClassAction;
 use LaraStrict\Providers\Actions\RunAppServiceProviderPipesAction;
+use LaraStrict\Providers\Contracts\GetAppServiceProviderForClassActionContract;
 use LaraStrict\Providers\Pipes\PreventLazyLoadingPipe;
 use LaraStrict\Providers\Pipes\SetFactoryResolvingProviderPipe;
 use LaraStrict\Testing\TestServiceProvider;
@@ -25,11 +27,16 @@ class LaraStrictServiceProvider extends AbstractBaseServiceProvider
 {
     public function register(): void
     {
+        // Can't use singleton here, because AbstractBaseServiceProvider can use these actions
+        $this->app->singleton(
+            GetAppServiceProviderForClassActionContract::class,
+            GetAppServiceProviderForClassAction::class
+        );
+        $this->app->singleton(RunAppServiceProviderPipesActionContract::class, RunAppServiceProviderPipesAction::class);
+
         // Add ability to "switch" the implementation - it is important to run it now.
         $this->app->singleton(ScheduleServiceContract::class, ScheduleServiceContract::class);
         $this->app->alias(ScheduleService::class, ScheduleServiceContract::class);
-
-        $this->app->bind(RunAppServiceProviderPipesActionContract::class, RunAppServiceProviderPipesAction::class);
 
         // Register our service providers
         $this->app->register(ConfigServiceProvider::class);

--- a/src/Providers/AbstractBaseServiceProvider.php
+++ b/src/Providers/AbstractBaseServiceProvider.php
@@ -20,8 +20,8 @@ abstract class AbstractBaseServiceProvider extends EventServiceProvider
     {
         parent::register();
 
-        /** @var RunAppServiceProviderPipesActionContract $runPipes */
         $runPipes = $this->app->make(RunAppServiceProviderPipesActionContract::class);
+        assert($runPipes instanceof RunAppServiceProviderPipesActionContract);
 
         $runPipes->execute($this->getAppServiceProvider(), $this->registerPipes());
     }
@@ -30,8 +30,8 @@ abstract class AbstractBaseServiceProvider extends EventServiceProvider
     {
         parent::boot();
 
-        /** @var RunAppServiceProviderPipesActionContract $runPipes */
         $runPipes = $this->app->make(RunAppServiceProviderPipesActionContract::class);
+        assert($runPipes instanceof RunAppServiceProviderPipesActionContract);
 
         $runPipes->execute($this->getAppServiceProvider(), $this->bootPipes());
     }
@@ -39,8 +39,8 @@ abstract class AbstractBaseServiceProvider extends EventServiceProvider
     public function getAppServiceProvider(): AppServiceProviderEntity
     {
         if ($this->appServiceProvider === null) {
-            /** @var CreateAppServiceProviderAction $action */
             $action = $this->app->make($this->getCreateAppServiceProviderActionClass());
+            assert($action instanceof CreateAppServiceProviderActionContract);
 
             $this->appServiceProvider = $action->execute($this->app, $this);
         }

--- a/src/Providers/Actions/GetAppServiceProviderForClassAction.php
+++ b/src/Providers/Actions/GetAppServiceProviderForClassAction.php
@@ -9,10 +9,11 @@ use Illuminate\Support\ServiceProvider;
 use LaraStrict\Cache\Contracts\CacheMeServiceContract;
 use LaraStrict\Cache\Enums\CacheMeStrategy;
 use LaraStrict\Providers\AbstractServiceProvider;
+use LaraStrict\Providers\Contracts\GetAppServiceProviderForClassActionContract;
 use LaraStrict\Providers\Entities\AppServiceProviderEntity;
 use LogicException;
 
-class GetAppServiceProviderForClassAction
+class GetAppServiceProviderForClassAction implements GetAppServiceProviderForClassActionContract
 {
     public function __construct(
         private readonly CacheMeServiceContract $cacheMeService,

--- a/src/Providers/Contracts/GetAppServiceProviderForClassActionContract.php
+++ b/src/Providers/Contracts/GetAppServiceProviderForClassActionContract.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Providers\Contracts;
+
+use LaraStrict\Providers\AbstractServiceProvider;
+use LaraStrict\Providers\Entities\AppServiceProviderEntity;
+
+interface GetAppServiceProviderForClassActionContract
+{
+    /**
+     * @param class-string<AbstractServiceProvider> $providerClass
+     */
+    public function execute(string $providerClass): AppServiceProviderEntity;
+}

--- a/src/Testing/Providers/Actions/GetAppServiceProviderForClassTestAction.php
+++ b/src/Testing/Providers/Actions/GetAppServiceProviderForClassTestAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Testing\Providers\Actions;
+
+use LaraStrict\Providers\Contracts\GetAppServiceProviderForClassActionContract;
+use LaraStrict\Providers\Entities\AppServiceProviderEntity;
+use LaraStrict\Testing\Laravel\TestingApplication;
+use LaraStrict\Testing\Providers\TestingLaraStrictServiceProvider;
+
+final class GetAppServiceProviderForClassTestAction implements GetAppServiceProviderForClassActionContract
+{
+    public function execute(string $providerClass): AppServiceProviderEntity
+    {
+        $app = new TestingApplication();
+        return new AppServiceProviderEntity(
+            application: $app,
+            serviceProvider: new TestingLaraStrictServiceProvider($app),
+            serviceName: 'Test',
+            serviceFileName: 'test',
+            serviceRootDir: 'test',
+            namespace: 'Test',
+        );
+    }
+}

--- a/src/Testing/Providers/TestingLaraStrictServiceProvider.php
+++ b/src/Testing/Providers/TestingLaraStrictServiceProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Testing\Providers;
+
+use LaraStrict\Providers\AbstractServiceProvider;
+
+final class TestingLaraStrictServiceProvider extends AbstractServiceProvider
+{
+}

--- a/src/Testing/Translations/TestingTranslator.php
+++ b/src/Testing/Translations/TestingTranslator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Testing\Translations;
+
+use Illuminate\Contracts\Translation\Translator;
+
+final class TestingTranslator implements Translator
+{
+    private string $locale = 'en';
+
+    /**
+     * @param array<string, mixed> $returnValueOnKey
+     */
+    public function __construct(
+        public array $returnValueOnKey = []
+    ) {
+    }
+
+    public function get($key, array $replace = [], $locale = null)
+    {
+        if (array_key_exists($key, $this->returnValueOnKey)) {
+            return $this->returnValueOnKey[$key];
+        }
+
+        return $this->wrap($key, $replace, $locale);
+    }
+
+    public function choice($key, $number, array $replace = [], $locale = null)
+    {
+        if (array_key_exists($key, $this->returnValueOnKey)) {
+            return $this->returnValueOnKey[$key];
+        }
+
+        if (is_int($number)) {
+            $finalNumber = (string) $number;
+        } elseif (is_array($number)) {
+            $finalNumber = implode(',', $number);
+        } else {
+            $finalNumber = (string) count($number);
+        }
+
+        return $this->wrap($key . ':' . $finalNumber, $replace, $locale);
+    }
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * @param array<string|int|float|bool> $replace
+     */
+    private function wrap(string $value, array $replace = [], string $locale = null): string
+    {
+        $return = $value;
+        if ($replace !== []) {
+            $return .= ':r:' . implode(',', $replace);
+        }
+
+        if ($locale !== null) {
+            $return .= ':l:' . $locale;
+        }
+
+        return $return;
+    }
+}

--- a/src/Translations/AbstractInternalTranslations.php
+++ b/src/Translations/AbstractInternalTranslations.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraStrict\Translations;
+
+use Countable;
+use Illuminate\Contracts\Translation\Translator;
+
+/**
+ * @internal
+ */
+abstract class AbstractInternalTranslations
+{
+    /**
+     * Returns localization path (file name)
+     */
+    abstract public function getLocalizationKey(): string;
+
+    abstract protected function getTranslator(): Translator;
+
+    protected function get(
+        string|array $key,
+        array $replace = [],
+        ?string $locale = null,
+        string $defaultValue = null
+    ): string {
+        $result = $this->getTranslator()
+            ->get($this->getKey($key), $replace, $locale);
+
+        if ($defaultValue !== null && $result === $this->getKey($key)) {
+            return $defaultValue;
+        }
+
+        return $result;
+    }
+
+    protected function getOptional(string|array $key, array $replace = [], ?string $locale = null): ?string
+    {
+        $result = $this->getTranslator()
+            ->get($this->getKey($key), $replace, $locale);
+
+        if ($result === $this->getKey($key)) {
+            return null;
+        }
+
+        return $result;
+    }
+
+    protected function getArray(string|array $key, array $replace = [], ?string $locale = null): array
+    {
+        return $this->getTranslator()
+            ->get($this->getKey($key), $replace, $locale);
+    }
+
+    protected function getChoice(
+        string|array $key,
+        int|array|Countable $number,
+        array $replace = [],
+        ?string $locale = null
+    ): string {
+        return $this->getTranslator()
+            ->choice($this->getKey($key), $number, $replace, $locale);
+    }
+
+    protected function getKey(string|array $key): string
+    {
+        $keys = [$this->getLocalizationKey(), ...(is_array($key) ? $key : [$key])];
+
+        return implode('.', $keys);
+    }
+}

--- a/src/Translations/AbstractProviderTranslations.php
+++ b/src/Translations/AbstractProviderTranslations.php
@@ -6,21 +6,34 @@ namespace LaraStrict\Translations;
 
 use Illuminate\Contracts\Translation\Translator;
 use LaraStrict\Providers\AbstractServiceProvider;
-use LaraStrict\Providers\Actions\GetAppServiceProviderForClassAction;
+use LaraStrict\Providers\Contracts\GetAppServiceProviderForClassActionContract;
+use LaraStrict\Testing\Providers\Actions\GetAppServiceProviderForClassTestAction;
+use LaraStrict\Testing\Translations\TestingTranslator;
 
-abstract class AbstractProviderTranslations extends AbstractTranslations
+abstract class AbstractProviderTranslations extends AbstractInternalTranslations
 {
     protected readonly string $providerKey;
 
-    public function __construct(
-        Translator $translator,
-        GetAppServiceProviderForClassAction $getAppServiceProviderForClassAction
+    final public function __construct(
+        private readonly Translator $translator,
+        GetAppServiceProviderForClassActionContract $getAppServiceProviderForClassAction
     ) {
-        parent::__construct($translator);
-
         $appService = $getAppServiceProviderForClassAction->execute($this->getProviderClass());
 
         $this->providerKey = $appService->serviceName;
+    }
+
+    /**
+     * @param array<string, mixed> $returnValueOnKey
+     */
+    public static function forTests(array $returnValueOnKey = []): static
+    {
+        return new static(new TestingTranslator($returnValueOnKey), new GetAppServiceProviderForClassTestAction());
+    }
+
+    protected function getTranslator(): Translator
+    {
+        return $this->translator;
     }
 
     /**

--- a/src/Translations/AbstractTranslations.php
+++ b/src/Translations/AbstractTranslations.php
@@ -4,70 +4,31 @@ declare(strict_types=1);
 
 namespace LaraStrict\Translations;
 
-use Countable;
 use Illuminate\Contracts\Translation\Translator;
+use LaraStrict\Testing\Translations\TestingTranslator;
 
 /**
  * - Makes translations testable
  * - Forces us making type strict access of translations
  * - Prevent reusing `file` name string (automatically wraps the key)
  */
-abstract class AbstractTranslations
+abstract class AbstractTranslations extends AbstractInternalTranslations
 {
-    public function __construct(
+    final public function __construct(
         private readonly Translator $translator
     ) {
     }
 
     /**
-     * Returns localization path (file name)
+     * @param array<string, mixed> $returnValueOnKey
      */
-    abstract public function getLocalizationKey(): string;
-
-    protected function get(
-        string|array $key,
-        array $replace = [],
-        ?string $locale = null,
-        string $defaultValue = null
-    ): string {
-        $result = $this->translator->get($this->getKey($key), $replace, $locale);
-
-        if ($defaultValue !== null && $result === $this->getKey($key)) {
-            return $defaultValue;
-        }
-
-        return $result;
-    }
-
-    protected function getOptional(string|array $key, array $replace = [], ?string $locale = null): ?string
+    public static function forTests(array $returnValueOnKey = []): static
     {
-        $result = $this->translator->get($this->getKey($key), $replace, $locale);
-
-        if ($result === $this->getKey($key)) {
-            return null;
-        }
-
-        return $result;
+        return new static(new TestingTranslator($returnValueOnKey));
     }
 
-    protected function getArray(string|array $key, array $replace = [], ?string $locale = null): array
+    protected function getTranslator(): Translator
     {
-        return $this->translator->get($this->getKey($key), $replace, $locale);
-    }
-
-    protected function getChoice(
-        string|array $key,
-        int|array|Countable $number,
-        array $replace = [],
-        ?string $locale = null
-    ): string {
-        return $this->translator->choice($this->getKey($key), $number, $replace, $locale);
-    }
-
-    protected function getKey(string|array $key): string
-    {
-        $keys = [$this->getLocalizationKey(), ...(is_array($key) ? $key : [$key])];
-
-        return implode('.', $keys);
+        return $this->translator;
     }
 }

--- a/tests/Feature/Testing/Translations/TestingTranslatorTest.php
+++ b/tests/Feature/Testing/Translations/TestingTranslatorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LaraStrict\Feature\Testing\Translations;
+
+use Countable;
+use LaraStrict\Testing\Translations\TestingTranslator;
+use PHPUnit\Framework\TestCase;
+
+class TestingTranslatorTest extends TestCase
+{
+    public TestingTranslator $translator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translator = new TestingTranslator();
+    }
+
+    public function testGet(): void
+    {
+        $this->assertEquals(
+            expected: 'test',
+            actual: $this->translator->get(key: 'test'),
+            message: 'TestingTranslator::get() should return the key as the value',
+        );
+        $this->assertEquals(
+            expected: 'test:r:1,2,3',
+            actual: $this->translator->get(key: 'test', replace: [1, 2, 3]),
+            message: 'TestingTranslator::get() should return the key as the value with replace',
+        );
+        $this->assertEquals(
+            expected: 'test:l:en',
+            actual: $this->translator->get(key: 'test', replace: [], locale: 'en'),
+            message: 'TestingTranslator::get() should return the key as the value with locale',
+        );
+        $this->assertEquals(
+            expected: 'test:r:1,2,3:l:en',
+            actual: $this->translator->get(key: 'test', replace: [1, 2, 3], locale: 'en'),
+            message: 'TestingTranslator::get() should return the key as the value with replace and locale',
+        );
+    }
+
+    public function testChoice(): void
+    {
+        $this->assertEquals(
+            expected: 'test:1',
+            actual: $this->translator->choice(key: 'test', number: 1),
+            message: 'TestingTranslator::choice() should return the key as the value',
+        );
+        $this->assertEquals(
+            expected: 'test:40:r:1,2,3',
+            actual: $this->translator->choice(key: 'test', number: 40, replace: [1, 2, 3]),
+            message: 'TestingTranslator::choice() should return the key as the value with replace',
+        );
+        $this->assertEquals(
+            expected: 'test:30:l:en',
+            actual: $this->translator->choice(key: 'test', number: 30, replace: [], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with locale',
+        );
+        $this->assertEquals(
+            expected: 'test:102:r:1,2,3:l:en',
+            actual: $this->translator->choice(key: 'test', number: 102, replace: [1, 2, 3], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with replace and locale',
+        );
+    }
+
+    public function testArrayChoice(): void
+    {
+        $this->assertEquals(
+            expected: 'test:1',
+            actual: $this->translator->choice(key: 'test', number: [1]),
+            message: 'TestingTranslator::choice() should return the key as the value',
+        );
+        $this->assertEquals(
+            expected: 'test:40:r:1,2,3',
+            actual: $this->translator->choice(key: 'test', number: [40], replace: [1, 2, 3]),
+            message: 'TestingTranslator::choice() should return the key as the value with replace',
+        );
+        $this->assertEquals(
+            expected: 'test:30:l:en',
+            actual: $this->translator->choice(key: 'test', number: [30], replace: [], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with locale',
+        );
+        $this->assertEquals(
+            expected: 'test:102,104:r:1,2,3:l:en',
+            actual: $this->translator->choice(key: 'test', number: [102, 104], replace: [1, 2, 3], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with replace and locale',
+        );
+    }
+
+    public function testCountableChoice(): void
+    {
+        $this->assertEquals(
+            expected: 'test:1',
+            actual: $this->translator->choice(key: 'test', number: new class() implements Countable {
+                public function count(): int
+                {
+                    return 1;
+                }
+            }),
+            message: 'TestingTranslator::choice() should return the key as the value',
+        );
+        $this->assertEquals(
+            expected: 'test:40:r:1,2,3',
+            actual: $this->translator->choice(key: 'test', number: new class() implements Countable {
+                public function count(): int
+                {
+                    return 40;
+                }
+            }, replace: [1, 2, 3]),
+            message: 'TestingTranslator::choice() should return the key as the value with replace',
+        );
+        $this->assertEquals(
+            expected: 'test:30:l:en',
+            actual: $this->translator->choice(key: 'test', number: new class() implements Countable {
+                public function count(): int
+                {
+                    return 30;
+                }
+            }, replace: [], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with locale',
+        );
+        $this->assertEquals(
+            expected: 'test:102:r:1,2,3:l:en',
+            actual: $this->translator->choice(key: 'test', number: new class() implements Countable {
+                public function count(): int
+                {
+                    return 102;
+                }
+            }, replace: [1, 2, 3], locale: 'en'),
+            message: 'TestingTranslator::choice() should return the key as the value with replace and locale',
+        );
+    }
+
+    public function testGetLocale(): void
+    {
+        $this->assertEquals(
+            expected: 'en',
+            actual: $this->translator->getLocale(),
+            message: 'TestingTranslator::getLocale() should return the default locale',
+        );
+        $this->translator->setLocale('de');
+        $this->assertEquals(
+            expected: 'de',
+            actual: $this->translator->getLocale(),
+            message: 'TestingTranslator::getLocale() should return the set locale',
+        );
+    }
+}

--- a/tests/Unit/Translations/AbstractProviderTranslationsTest.php
+++ b/tests/Unit/Translations/AbstractProviderTranslationsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LaraStrict\Unit\Translations;
+
+use PHPUnit\Framework\TestCase;
+use Tests\LaraStrict\Feature\Providers\Translations\TestTranslation;
+
+class AbstractProviderTranslationsTest extends TestCase
+{
+    private TestTranslation $translation;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->translation = TestTranslation::forTests();
+    }
+
+    public function testGet(): void
+    {
+        $this->assertEquals('Test::test.test', $this->translation->getTest());
+    }
+}

--- a/tests/Unit/Translations/AbstractTranslationsTest.php
+++ b/tests/Unit/Translations/AbstractTranslationsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\LaraStrict\Unit\Translations;
+
+use PHPUnit\Framework\TestCase;
+use Tests\LaraStrict\Feature\Translations\MyTranslations;
+
+class AbstractTranslationsTest extends TestCase
+{
+    final public const ExpectedArray = [
+        'one' => 'One way',
+        'two' => 'Two way',
+    ];
+
+    private MyTranslations $translations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translations = MyTranslations::forTests([
+            'package::test.ways' => self::ExpectedArray,
+        ]);
+    }
+
+    public function testGetString(): void
+    {
+        $this->assertEquals('package::test.name', $this->translations->getMyTest());
+    }
+
+    public function testChoice(): void
+    {
+        $this->assertEquals('package::test.minutes_ago:1:r:1', $this->translations->getAgo(1));
+        $this->assertEquals('package::test.minutes_ago:2:r:2', $this->translations->getAgo(2));
+        $this->assertEquals('package::test.minutes_ago:5:r:5', $this->translations->getAgo(5));
+    }
+
+    public function testArray(): void
+    {
+        $this->assertEquals(self::ExpectedArray, $this->translations->getWays());
+    }
+
+    public function testGetWay(): void
+    {
+        $this->assertEquals('package::test.ways.one', $this->translations->getWay('one'));
+        $this->assertEquals('package::test.ways.two', $this->translations->getWay('two'));
+    }
+
+    public function testGetWayWithArrayKeys(): void
+    {
+        $this->assertEquals('package::test.ways.one', $this->translations->getWayArrayKeys('one'));
+        $this->assertEquals('package::test.ways.two', $this->translations->getWayArrayKeys('two'));
+    }
+
+    public function testGetWayNullableAlwaysReturnsNullBecauseSameKeyIsReturned(): void
+    {
+        $this->assertEquals(null, $this->translations->getWayNullable('one'));
+        $this->assertEquals(null, $this->translations->getWayNullable('two'));
+        $this->assertEquals(null, $this->translations->getWayNullable('s'));
+    }
+
+    public function testDefaultValueByLaravel(): void
+    {
+        $this->assertEquals('package::test.test', $this->translations->getNotFoundLaravel());
+    }
+
+    public function testCustomDefaultValue(): void
+    {
+        $this->assertEquals('test123', $this->translations->getCustomNotFound());
+    }
+
+    public function testCustomDefaultNullValue(): void
+    {
+        $this->assertEquals(null, $this->translations->getCustomNotFoundNullable());
+    }
+}


### PR DESCRIPTION
- Returns used key with replace/locale arguments as a string
- Use MyTranslations::forTests() in your tests
- Check TestingTranslatorTest for formating examples