### PR TITLE
Internal variables for generated assert has prefix underscore

### DIFF
--- a/src/Testing/Commands/MakeExpectationCommand.php
+++ b/src/Testing/Commands/MakeExpectationCommand.php
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'make:expectation', description: 'Make expectation class for given class')]
 class MakeExpectationCommand extends Command
 {
-    private const HookProperty = 'hook';
+    private const HookProperty = '_hook';
 
     protected $signature = 'make:expectation
         {class : Class name of path to class using PSR-4 specs}
@@ -195,33 +195,33 @@ class MakeExpectationCommand extends Command
         $assertClass->addMember($assertMethod);
 
         $assertMethod->addBody(sprintf(
-            '$expectation = $this->getExpectation(%s);',
+            '$_expectation = $this->getExpectation(%s);',
             $expectationClassName . '::class'
         ));
 
         $hookParameters = [];
 
         if ($parameters !== []) {
-            $assertMethod->addBody('$message = $this->getDebugMessage();');
+            $assertMethod->addBody('$_message = $this->getDebugMessage();');
             $assertMethod->addBody('');
 
             foreach ($parameters as $parameter) {
                 $hookParameters[] = sprintf('$%s', $parameter->name);
                 $assertMethod->addBody(sprintf(
-                    'Assert::assertEquals($expectation->%s, $%s, $message);',
+                    'Assert::assertEquals($_expectation->%s, $%s, $_message);',
                     $parameter->name,
                     $parameter->name
                 ));
             }
         }
 
-        $hookParameters[] = '$expectation';
+        $hookParameters[] = '$_expectation';
 
         $assertMethod->addBody('');
 
-        $assertMethod->addBody(sprintf('if (is_callable($expectation->%s)) {', self::HookProperty));
+        $assertMethod->addBody(sprintf('if (is_callable($_expectation->%s)) {', self::HookProperty));
         $assertMethod->addBody(sprintf(
-            '    call_user_func($expectation->%s, %s);',
+            '    call_user_func($_expectation->%s, %s);',
             self::HookProperty,
             implode(', ', $hookParameters),
         ));
@@ -240,7 +240,7 @@ class MakeExpectationCommand extends Command
         switch ($enumReturnType) {
             case PhpType::Mixed:
                 $assertMethod->addBody('');
-                $assertMethod->addBody('return $expectation->return;');
+                $assertMethod->addBody('return $_expectation->return;');
                 break;
             case PhpType::Self:
             case PhpType::Static:

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractAssert.php.stub
@@ -53,15 +53,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
 
     function self(string $first, int $second, bool $third): self
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -72,15 +72,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThis(string $first, int $second, bool $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -95,15 +95,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThisParams($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -114,18 +114,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocBool($first, $second, callable $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -133,18 +133,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocString($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -152,18 +152,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocFloat($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -171,18 +171,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocMixed($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -190,15 +190,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocStatic($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -209,58 +209,58 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function selfViaClass($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noReturn($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
     }
 
     function mixed($first, $second, $third): mixed
     {
-        $expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noParams(): string
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
+        $_expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractNoParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractNoParamsExpectation.php.stub
@@ -7,11 +7,11 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractNoParamsExpectation
 {
     /**
-     * @param \Closure(self):void|null $hook
+     * @param \Closure(self):void|null $_hook
      */
     public function __construct(
         public readonly string $return,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractNoReturnExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractNoReturnExpectation.php.stub
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractNoReturnExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocBoolExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocBoolExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocBoolExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,\Closure,self):void|null $hook
+     * @param \Closure(mixed,mixed,\Closure,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly \Closure $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocFloatExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocFloatExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocFloatExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocStaticExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocStaticExpectation.php.stub
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocStaticExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocStringExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocStringExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocStringExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocThisExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocThisExpectation.php.stub
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocThisExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocThisParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractPhpDocThisParamsExpectation.php.stub
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocThisParamsExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractSelfExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractSelfExpectation.php.stub
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractSelfExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractSelfViaClassExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/MultiFunctionContractSelfViaClassExpectation.php.stub
@@ -7,14 +7,14 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractSelfViaClassExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/SimpleActionContractAssert.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/SimpleActionContractAssert.php
@@ -19,15 +19,15 @@ class SimpleActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpe
 
     function execute(string $first, int $second, bool $third)
     {
-        $expectation = $this->getExpectation(SimpleActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(SimpleActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/SimpleActionContractExpectation.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/SimpleActionContractExpectation.php
@@ -7,13 +7,13 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class SimpleActionContractExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractAssert.php.stub
@@ -36,29 +36,29 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): void {
-        $expectation = $this->getExpectation(TestActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): ?int {
-        $expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnIntersectionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $return,
@@ -28,7 +28,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnRequiredActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $return,
@@ -28,7 +28,7 @@ final class TestReturnRequiredActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): \LaraStrict\Testing\Laravel\TestingApplication|string|int|null {
-        $expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnUnionActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnUnionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractAssert.php.stub
@@ -53,15 +53,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
 
     function self(string $first, int $second, bool $third): self
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -72,15 +72,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThis(string $first, int $second, bool $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -95,15 +95,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThisParams($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -114,18 +114,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocBool($first, $second, callable $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -133,18 +133,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocString($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -152,18 +152,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocFloat($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -171,18 +171,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocMixed($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -190,15 +190,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocStatic($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -209,58 +209,58 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function selfViaClass($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noReturn($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
     }
 
     function mixed($first, $second, $third): mixed
     {
-        $expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noParams(): string
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
+        $_expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractNoParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractNoParamsExpectation.php.stub
@@ -7,11 +7,11 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractNoParamsExpectation
 {
     /**
-     * @param \Closure(self):void|null $hook
+     * @param \Closure(self):void|null $_hook
      */
     public function __construct(
         public readonly string $return,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractNoReturnExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractNoReturnExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractNoReturnExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocBoolExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocBoolExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocBoolExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,\Closure,self):void|null $hook
+     * @param \Closure(mixed,mixed,\Closure,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly \Closure $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocFloatExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocFloatExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocFloatExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocStaticExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocStaticExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocStaticExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocStringExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocStringExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocStringExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocThisExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocThisExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocThisExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocThisParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractPhpDocThisParamsExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractPhpDocThisParamsExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractSelfExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractSelfExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractSelfExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractSelfViaClassExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.MultiFunctionContractSelfViaClassExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class MultiFunctionContractSelfViaClassExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractAssert.php.stub
@@ -36,29 +36,29 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): void {
-        $expectation = $this->getExpectation(TestActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): ?int {
-        $expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnIntersectionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnIntersectionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $return,
@@ -28,7 +28,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnRequiredActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnRequiredActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $return,
@@ -28,7 +28,7 @@ final class TestReturnRequiredActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): \LaraStrict\Testing\Laravel\TestingApplication|string|int|null {
-        $expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnUnionActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand;
 final class TestReturnUnionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractAssert.php.stub
@@ -53,15 +53,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
 
     function self(string $first, int $second, bool $third): self
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -72,15 +72,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThis(string $first, int $second, bool $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -95,15 +95,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocThisParams($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocThisParamsExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -114,18 +114,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocBool($first, $second, callable $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocBoolExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -133,18 +133,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocString($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStringExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -152,18 +152,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocFloat($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocFloatExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -171,18 +171,18 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocMixed($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     /**
@@ -190,15 +190,15 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function phpDocStatic($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractPhpDocStaticExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
         return $this;
@@ -209,58 +209,58 @@ class MultiFunctionContractAssert extends \LaraStrict\Testing\Assert\AbstractExp
      */
     function selfViaClass($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractSelfViaClassExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noReturn($first, $second, $third)
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractNoReturnExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
     }
 
     function mixed($first, $second, $third): mixed
     {
-        $expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(MultiFunctionContractMixedExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->first, $first, $message);
-        Assert::assertEquals($expectation->second, $second, $message);
-        Assert::assertEquals($expectation->third, $third, $message);
+        Assert::assertEquals($_expectation->first, $first, $_message);
+        Assert::assertEquals($_expectation->second, $second, $_message);
+        Assert::assertEquals($_expectation->third, $third, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $first, $second, $third, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $first, $second, $third, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 
     function noParams(): string
     {
-        $expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
+        $_expectation = $this->getExpectation(MultiFunctionContractNoParamsExpectation::class);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractNoParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractNoParamsExpectation.php.stub
@@ -7,11 +7,11 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractNoParamsExpectation
 {
     /**
-     * @param \Closure(self):void|null $hook
+     * @param \Closure(self):void|null $_hook
      */
     public function __construct(
         public readonly string $return,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractNoReturnExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractNoReturnExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractNoReturnExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocBoolExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocBoolExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocBoolExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,\Closure,self):void|null $hook
+     * @param \Closure(mixed,mixed,\Closure,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly \Closure $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocFloatExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocFloatExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocFloatExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocMixedExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocMixedExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocMixedExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocStaticExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocStaticExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocStaticExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocStringExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocStringExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocStringExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocThisExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocThisExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocThisExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocThisParamsExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractPhpDocThisParamsExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractPhpDocThisParamsExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractSelfExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractSelfExpectation.php.stub
@@ -7,13 +7,13 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractSelfExpectation
 {
     /**
-     * @param \Closure(string,int,bool,self):void|null $hook
+     * @param \Closure(string,int,bool,self):void|null $_hook
      */
     public function __construct(
         public readonly string $first,
         public readonly int $second,
         public readonly bool $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractSelfViaClassExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.MultiFunctionContractSelfViaClassExpectation.php.stub
@@ -7,14 +7,14 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class MultiFunctionContractSelfViaClassExpectation
 {
     /**
-     * @param \Closure(mixed,mixed,mixed,self):void|null $hook
+     * @param \Closure(mixed,mixed,mixed,self):void|null $_hook
      */
     public function __construct(
         public readonly mixed $return,
         public readonly mixed $first,
         public readonly mixed $second,
         public readonly mixed $third,
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractAssert.php.stub
@@ -36,29 +36,29 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): void {
-        $expectation = $this->getExpectation(TestActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $int,
@@ -27,7 +27,7 @@ final class TestActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): ?int {
-        $expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly ?int $return,
@@ -28,7 +28,7 @@ final class TestReturnActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnIntersectionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnIntersectionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $return,
@@ -28,7 +28,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnRequiredActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnRequiredActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly int $return,
@@ -28,7 +28,7 @@ final class TestReturnRequiredActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractAssert.php.stub
@@ -36,31 +36,31 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
     ): \LaraStrict\Testing\Laravel\TestingApplication|string|int|null {
-        $expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
-        $message = $this->getDebugMessage();
+        $_expectation = $this->getExpectation(TestReturnUnionActionContractExpectation::class);
+        $_message = $this->getDebugMessage();
 
-        Assert::assertEquals($expectation->int, $int, $message);
-        Assert::assertEquals($expectation->string, $string, $message);
-        Assert::assertEquals($expectation->noTypeHint, $noTypeHint, $message);
-        Assert::assertEquals($expectation->type, $type, $message);
-        Assert::assertEquals($expectation->testingApplication, $testingApplication, $message);
-        Assert::assertEquals($expectation->multi, $multi, $message);
-        Assert::assertEquals($expectation->multiNull, $multiNull, $message);
-        Assert::assertEquals($expectation->multiNullDefault, $multiNullDefault, $message);
-        Assert::assertEquals($expectation->optional, $optional, $message);
-        Assert::assertEquals($expectation->optionalString, $optionalString, $message);
-        Assert::assertEquals($expectation->constant, $constant, $message);
-        Assert::assertEquals($expectation->constantClass, $constantClass, $message);
-        Assert::assertEquals($expectation->enumDefault, $enumDefault, $message);
-        Assert::assertEquals($expectation->noTypeHintDefault, $noTypeHintDefault, $message);
-        Assert::assertEquals($expectation->customConstants, $customConstants, $message);
-        Assert::assertEquals($expectation->object, $object, $message);
-        Assert::assertEquals($expectation->intersectionType, $intersectionType, $message);
+        Assert::assertEquals($_expectation->int, $int, $_message);
+        Assert::assertEquals($_expectation->string, $string, $_message);
+        Assert::assertEquals($_expectation->noTypeHint, $noTypeHint, $_message);
+        Assert::assertEquals($_expectation->type, $type, $_message);
+        Assert::assertEquals($_expectation->testingApplication, $testingApplication, $_message);
+        Assert::assertEquals($_expectation->multi, $multi, $_message);
+        Assert::assertEquals($_expectation->multiNull, $multiNull, $_message);
+        Assert::assertEquals($_expectation->multiNullDefault, $multiNullDefault, $_message);
+        Assert::assertEquals($_expectation->optional, $optional, $_message);
+        Assert::assertEquals($_expectation->optionalString, $optionalString, $_message);
+        Assert::assertEquals($_expectation->constant, $constant, $_message);
+        Assert::assertEquals($_expectation->constantClass, $constantClass, $_message);
+        Assert::assertEquals($_expectation->enumDefault, $enumDefault, $_message);
+        Assert::assertEquals($_expectation->noTypeHintDefault, $noTypeHintDefault, $_message);
+        Assert::assertEquals($_expectation->customConstants, $customConstants, $_message);
+        Assert::assertEquals($_expectation->object, $object, $_message);
+        Assert::assertEquals($_expectation->intersectionType, $intersectionType, $_message);
 
-        if (is_callable($expectation->hook)) {
-            call_user_func($expectation->hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $expectation);
+        if (is_callable($_expectation->_hook)) {
+            call_user_func($_expectation->_hook, $int, $string, $noTypeHint, $type, $testingApplication, $multi, $multiNull, $multiNullDefault, $optional, $optionalString, $constant, $constantClass, $enumDefault, $noTypeHintDefault, $customConstants, $object, $intersectionType, $_expectation);
         }
 
-        return $expectation->return;
+        return $_expectation->return;
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnUnionActionContractExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionExpectation.php.stub
@@ -7,7 +7,7 @@ namespace App\Integration\LaraStrict\Feature\Testing\Commands\MakeExpectationCom
 final class TestReturnUnionActionExpectation
 {
     /**
-     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $hook
+     * @param \Closure(int,string,mixed,\LaraStrict\Enums\EnvironmentType,\LaraStrict\Testing\Laravel\TestingApplication,string|int,string|int|null,string|int|null,string,string,string,int,\LaraStrict\Enums\EnvironmentType,mixed,string,\LaraStrict\Testing\Laravel\TestingApplication,ArrayAccess&Illuminate\Support\Enumerable,self):void|null $_hook
      */
     public function __construct(
         public readonly \LaraStrict\Testing\Laravel\TestingApplication|string|int|null $return,
@@ -28,7 +28,7 @@ final class TestReturnUnionActionExpectation
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,
         public readonly \LaraStrict\Testing\Laravel\TestingApplication $object = new \LaraStrict\Testing\Laravel\TestingApplication(/* unknown */),
         public readonly \ArrayAccess&\Illuminate\Support\Enumerable $intersectionType = new \Illuminate\Support\Collection(/* unknown */),
-        public readonly ?\Closure $hook = null,
+        public readonly ?\Closure $_hook = null,
     ) {
     }
 }

--- a/tests/Feature/Testing/Commands/MakeExpectationCommandRealTest.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommandRealTest.php
@@ -61,7 +61,7 @@ class MakeExpectationCommandRealTest extends TestCase
         $hookCalled = false;
         $assert = new SimpleActionContractAssert([
             new SimpleActionContractExpectation('test', 2, false),
-            new SimpleActionContractExpectation('test2', 1, true, hook: function (
+            new SimpleActionContractExpectation('test2', 1, true, _hook: function (
                 string $first,
                 int $second,
                 bool $third,


### PR DESCRIPTION
Bug:

I use interface, where parameter is `$message`. And internal variable rewrite this parameter.

example 
```php
    function captureMessage(string $message, \Sentry\Severity $level = null): ?\Sentry\EventId
    {
        ...
        $message = $this->getDebugMessage(); // <------ Here is rewritten incoming parameter

        Assert::assertEquals($expectation->message, $message, $message);

    }
```