### PR TITLE
fix(Database): OrderByValuesScope is now from ASC to DESC order of gi…

### DIFF
--- a/src/Database/Scopes/OrderByValuesScope.php
+++ b/src/Database/Scopes/OrderByValuesScope.php
@@ -6,16 +6,25 @@ namespace LaraStrict\Database\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 
 class OrderByValuesScope extends AbstractScope
 {
+    private readonly string $direction;
+
     /**
      * @param array<string|int> $values
      */
     public function __construct(
         private readonly array $values,
-        private readonly string $column
+        private readonly string $column,
+        string $direction = 'ASC'
     ) {
+        $this->direction = strtoupper((string) $direction);
+
+        if ($this->direction !== 'ASC' && $this->direction !== 'DESC') {
+            throw new InvalidArgumentException('Direction must be ASC or DESC');
+        }
     }
 
     public function apply(Builder $builder, Model $model): void
@@ -23,7 +32,7 @@ class OrderByValuesScope extends AbstractScope
         $placeholders = array_map(static fn () => '?', $this->values);
 
         $builder->orderByRaw(
-            'FIELD(`' . $this->column . '`, ' . implode(', ', $placeholders) . ') DESC',
+            'FIELD(`' . $this->column . '`, ' . implode(', ', $placeholders) . ') ' . $this->direction,
             $this->values
         );
     }

--- a/tests/Feature/Database/Scopes/OrderByValuesScopeTest.php
+++ b/tests/Feature/Database/Scopes/OrderByValuesScopeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\LaraStrict\Feature\Database\Scopes;
 
+use Closure;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use LaraStrict\Database\Scopes\OrderByValuesScope;
 use Tests\LaraStrict\Feature\Database\Models\Test;
@@ -11,17 +12,91 @@ use Tests\LaraStrict\Feature\TestCase;
 
 class OrderByValuesScopeTest extends TestCase
 {
-    public function testApply(): void
+    /**
+     * @return array<string|int, array{0: Closure(static):void}>
+     */
+    public function data(): array
     {
+        return [
+            [
+                static fn (self $self) => $self->assert(direction: 'ASC', expectedDirection: 'ASC'),
+            ],
+            [
+                static fn (self $self) => $self->assert(direction: 'DESC', expectedDirection: 'DESC'),
+            ],
+            [
+                static fn (self $self) => $self->assert(direction: 'desc', expectedDirection: 'DESC'),
+            ],
+            [
+                static fn (self $self) => $self->assert(direction: 'asc', expectedDirection: 'ASC'),
+            ],
+            [
+                static fn (self $self) => $self->assert(direction: null, expectedDirection: 'ASC'),
+            ],
+        ];
+    }
+
+    /**
+     * @param Closure(static):void $assert
+     *
+     * @dataProvider data
+     */
+    public function test(Closure $assert): void
+    {
+        $assert($this);
+    }
+
+    public function assert(?string $direction, string $expectedDirection): void
+    {
+        $values = ['1', 2, 's33'];
+        $scope = $direction === null
+            ? new OrderByValuesScope($values, Test::AttributeTest)
+            : new OrderByValuesScope($values, Test::AttributeTest, $direction);
+
         $query = Test::query()
             ->withoutGlobalScope(new SoftDeletingScope())
-            ->withGlobalScope('test', new OrderByValuesScope(['1', 2, 's33'], Test::AttributeTest));
+            ->withGlobalScope('test', $scope);
 
         $this->assertEquals(
-            expected: 'select * from "tests" order by FIELD(`test`, ?, ?, ?) DESC',
+            expected: 'select * from "tests" order by FIELD(`test`, ?, ?, ?) ' . $expectedDirection,
             actual: $query->toSql()
         );
 
-        $this->assertEquals(expected: ['1', 2, 's33'], actual: $query->getBindings());
+        $this->assertEquals(expected: $values, actual: $query->getBindings());
+    }
+
+    /**
+     * @return array<string|int, array{0: Closure(static):void}>
+     */
+    public function dataInvalid(): array
+    {
+        return [
+            [
+                static fn (self $self) => $self->assertInvalid(direction: 'invalid'),
+            ],
+            [
+                static fn (self $self) => $self->assertInvalid(direction: 'asio'),
+            ],
+
+            [
+                static fn (self $self) => $self->assertInvalid(direction: 'descio'),
+            ],
+        ];
+    }
+
+    /**
+     * @param Closure(static):void $assert
+     *
+     * @dataProvider dataInvalid
+     */
+    public function testInvalid(Closure $assert): void
+    {
+        $assert($this);
+    }
+
+    public function assertInvalid(string $direction): void
+    {
+        $this->expectExceptionMessage('Direction must be ASC or DESC');
+        new OrderByValuesScope([], Test::AttributeTest, $direction);
     }
 }


### PR DESCRIPTION
…ven values

BREAKING CHANGE: Values must be ordered from prefered order to last wanted order (now it was incorrectly used)