### PR TITLE
feat(CacheMeService): ttl defined like seconds instead of minutes

### DIFF
--- a/src/Cache/Constants/CacheExpirations.php
+++ b/src/Cache/Constants/CacheExpirations.php
@@ -5,17 +5,49 @@ declare(strict_types=1);
 namespace LaraStrict\Cache\Constants;
 
 /**
- * Stores on minutes.
+ * Stores in seconds
  */
-class CacheExpirations
+final class CacheExpirations
 {
     /**
-     * 720 minutes - 12 hours.
+     * minute in seconds
      */
-    final public const HalfDay = 720;
+    public const Minute = 60;
 
     /**
-     * 1 days.
+     * hour in seconds
      */
-    final public const Long = 44640;
+    public const Hour = 60 * self::Minute;
+
+    /**
+     * day in seconds
+     */
+    public const Day = 24 * self::Hour;
+
+    /**
+     * week in seconds
+     */
+    public const Week = 7 * self::Day;
+
+    /**
+     * average month in seconds
+     */
+    public const Month = 2_629_800;
+
+    /**
+     * average year in seconds
+     */
+    public const Year = 31_557_600;
+
+    /**
+     * Fixed value
+     *
+     * @deprecated
+     */
+    public const Long = self::Month;
+
+    /**
+     * @deprecated
+     */
+    public const HalfDay = 12 * self::Hour;
 }

--- a/src/Cache/Contracts/CacheMeServiceContract.php
+++ b/src/Cache/Contracts/CacheMeServiceContract.php
@@ -24,7 +24,7 @@ interface CacheMeServiceContract
         string $key,
         Closure $getValue,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         bool $log = true
     ): mixed;
@@ -36,7 +36,7 @@ interface CacheMeServiceContract
         string $key,
         mixed $value,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         bool $log = true
     ): void;

--- a/src/Cache/Services/CacheMeService.php
+++ b/src/Cache/Services/CacheMeService.php
@@ -30,17 +30,23 @@ class CacheMeService implements CacheMeServiceContract
 
     /**
      * Stores in memory and uses the default cache.
+     *
+     * @param ?int $minutes - deprecated use $seconds
      */
     public function get(
         string $key,
         Closure $getValue,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
-        bool $log = true
+        bool $log = true,
+        ?int $minutes = null
     ): mixed {
         if ($strategy === CacheMeStrategy::None) {
             return $this->container->call($getValue);
+        }
+        if ($minutes !== null) {
+            $seconds = $minutes;
         }
 
         $value = null;
@@ -72,7 +78,7 @@ class CacheMeService implements CacheMeServiceContract
                     key: $key,
                     value: $value,
                     tags: $tags,
-                    minutes: $minutes,
+                    seconds: $seconds,
                     log: false
                 );
             }
@@ -91,7 +97,7 @@ class CacheMeService implements CacheMeServiceContract
                     key: $key,
                     value: $value,
                     tags: $tags,
-                    minutes: $minutes,
+                    seconds: $seconds,
                     log: $log
                 );
             }
@@ -107,7 +113,7 @@ class CacheMeService implements CacheMeServiceContract
         string $key,
         mixed $value,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         bool $log = true
     ): void {
@@ -116,7 +122,7 @@ class CacheMeService implements CacheMeServiceContract
             key: $key,
             value: $value,
             tags: $tags,
-            minutes: $minutes,
+            seconds: $seconds,
             log: $log
         );
     }
@@ -244,7 +250,7 @@ class CacheMeService implements CacheMeServiceContract
         string $key,
         mixed $value,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         bool $log = true
     ): void {
         if ($repositories === []) {
@@ -254,14 +260,14 @@ class CacheMeService implements CacheMeServiceContract
         if ($log) {
             $this->logger->debug('Storing cache', [
                 'key' => $key,
-                'minutes' => $minutes,
+                'seconds' => $seconds,
                 'tags' => $tags,
                 'store' => array_map(static fn (CacheContract $store) => $store->getStore()::class, $repositories),
             ]);
         }
 
         foreach ($repositories as $store) {
-            $store->set($key, $value, $minutes);
+            $store->set($key, $value, $seconds);
         }
     }
 

--- a/src/Context/Services/ContextService.php
+++ b/src/Context/Services/ContextService.php
@@ -45,7 +45,7 @@ class ContextService implements ContextServiceContract
             key: $fullCacheKey,
             value: $value,
             tags: $this->getTags($context),
-            minutes: $context->getCacheTtl(),
+            seconds: $context->getCacheTtl(),
         );
     }
 
@@ -57,7 +57,7 @@ class ContextService implements ContextServiceContract
             key: $fullCacheKey,
             value: $value,
             tags: $this->getTags($context),
-            minutes: $context->getCacheTtl(),
+            seconds: $context->getCacheTtl(),
             strategy: CacheMeStrategy::Memory,
         );
     }
@@ -70,7 +70,7 @@ class ContextService implements ContextServiceContract
             key: $fullCacheKey,
             getValue: $createState,
             tags: $this->getTags($context),
-            minutes: $context->getCacheTtl(),
+            seconds: $context->getCacheTtl(),
             strategy: $this->cacheStrategy($context)
         );
     }

--- a/src/Testing/Cache/Contracts/CacheMeServiceContractAssert.php
+++ b/src/Testing/Cache/Contracts/CacheMeServiceContractAssert.php
@@ -46,7 +46,7 @@ class CacheMeServiceContractAssert extends AbstractExpectationCallsMap implement
         string $key,
         Closure $getValue,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         bool $log = true,
     ): mixed {
@@ -55,7 +55,7 @@ class CacheMeServiceContractAssert extends AbstractExpectationCallsMap implement
 
         Assert::assertEquals($expectation->key, $key, $message);
         Assert::assertEquals($expectation->tags, $tags, $message);
-        Assert::assertEquals($expectation->minutes, $minutes, $message);
+        Assert::assertEquals($expectation->minutes, $seconds, $message);
         Assert::assertEquals($expectation->strategy, $strategy, $message);
         Assert::assertEquals($expectation->log, $log, $message);
 
@@ -71,7 +71,7 @@ class CacheMeServiceContractAssert extends AbstractExpectationCallsMap implement
         string $key,
         mixed $value,
         array $tags = [],
-        int $minutes = CacheExpirations::HalfDay,
+        int $seconds = CacheExpirations::Day,
         CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         bool $log = true,
     ): void {
@@ -81,7 +81,7 @@ class CacheMeServiceContractAssert extends AbstractExpectationCallsMap implement
         Assert::assertEquals($expectation->key, $key, $message);
         Assert::assertEquals($expectation->value, $value, $message);
         Assert::assertEquals($expectation->tags, $tags, $message);
-        Assert::assertEquals($expectation->minutes, $minutes, $message);
+        Assert::assertEquals($expectation->minutes, $seconds, $message);
         Assert::assertEquals($expectation->strategy, $strategy, $message);
         Assert::assertEquals($expectation->log, $log, $message);
     }

--- a/src/Testing/Cache/Contracts/CacheMeServiceContractGetExpectation.php
+++ b/src/Testing/Cache/Contracts/CacheMeServiceContractGetExpectation.php
@@ -16,7 +16,7 @@ final class CacheMeServiceContractGetExpectation
     public function __construct(
         public readonly string $key,
         public readonly array $tags = [],
-        public readonly int $minutes = CacheExpirations::HalfDay,
+        public readonly int $minutes = CacheExpirations::Day,
         public readonly CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         public readonly ?Closure $callGetValueHook = null,
         public readonly bool $log = true,

--- a/src/Testing/Cache/Contracts/CacheMeServiceContractSetExpectation.php
+++ b/src/Testing/Cache/Contracts/CacheMeServiceContractSetExpectation.php
@@ -13,7 +13,7 @@ final class CacheMeServiceContractSetExpectation
         public readonly string $key,
         public readonly mixed $value,
         public readonly array $tags = [],
-        public readonly int $minutes = CacheExpirations::HalfDay,
+        public readonly int $minutes = CacheExpirations::Day,
         public readonly CacheMeStrategy $strategy = CacheMeStrategy::MemoryAndRepository,
         public readonly bool $log = true,
     ) {

--- a/tests/Feature/Testing/Cache/Contracts/CacheMeServiceContractAssertTest.php
+++ b/tests/Feature/Testing/Cache/Contracts/CacheMeServiceContractAssertTest.php
@@ -54,7 +54,7 @@ class CacheMeServiceContractAssertTest extends TestCase
                     key: self::Key,
                     value: self::Return,
                     tags: [self::Return],
-                    minutes: 230,
+                    seconds: 230,
                     strategy: CacheMeStrategy::Memory,
                 ),
                 checkResult: false,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestAction.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestAction.php
@@ -26,7 +26,7 @@ class TestAction implements TestActionContract
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContract.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContract.php
@@ -26,7 +26,7 @@ interface TestActionContract
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionContractExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestActionExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnAction.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnAction.php
@@ -27,7 +27,7 @@ class TestReturnAction
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContract.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContract.php
@@ -26,7 +26,7 @@ interface TestReturnActionContract
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionAction.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionAction.php
@@ -26,7 +26,7 @@ class TestReturnIntersectionAction
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnIntersectionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredAction.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredAction.php
@@ -26,7 +26,7 @@ class TestReturnRequiredAction
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnRequiredActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnRequiredActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionAction.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionAction.php
@@ -26,7 +26,7 @@ class TestReturnUnionAction implements TestReturnUnionActionContract
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContract.php
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContract.php
@@ -27,7 +27,7 @@ interface TestReturnUnionActionContract
         ?string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = CacheExpirations::HalfDay,
+        int $constantClass = CacheExpirations::Day,
         EnvironmentType $enumDefault = EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/TestReturnUnionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionContractExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestActionExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnIntersectionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnRequiredActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnRequiredActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/one.TestReturnUnionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestActionContractAssert extends \LaraStrict\Testing\Assert\AbstractExpect
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionContractExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestActionExpectation.php.stub
@@ -21,7 +21,7 @@ final class TestActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnActionContractAssert extends \LaraStrict\Testing\Assert\Abstract
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnIntersectionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnIntersectionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnIntersectionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnRequiredActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnRequiredActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnRequiredActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractAssert.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractAssert.php.stub
@@ -29,7 +29,7 @@ class TestReturnUnionActionContractAssert extends \LaraStrict\Testing\Assert\Abs
         string $optional = null,
         string $optionalString = 'test',
         string $constant = DIRECTORY_SEPARATOR,
-        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         $noTypeHintDefault = null,
         string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionContractExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionContractExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,

--- a/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionExpectation.php.stub
+++ b/tests/Feature/Testing/Commands/MakeExpectationCommand/two.TestReturnUnionActionExpectation.php.stub
@@ -22,7 +22,7 @@ final class TestReturnUnionActionExpectation
         public readonly ?string $optional = null,
         public readonly string $optionalString = 'test',
         public readonly string $constant = \DIRECTORY_SEPARATOR,
-        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::HalfDay,
+        public readonly int $constantClass = \LaraStrict\Cache\Constants\CacheExpirations::Day,
         public readonly \LaraStrict\Enums\EnvironmentType $enumDefault = \LaraStrict\Enums\EnvironmentType::Testing,
         public readonly mixed $noTypeHintDefault = null,
         public readonly string $customConstants = \Tests\LaraStrict\Feature\Testing\Commands\MakeExpectationCommand\Constants\CustomConstants::TEST,


### PR DESCRIPTION
- výchozí konstanta pro zakešování jsem dal den namísto půl den, je to v pohodě?
- minutové konstanty jsem převedl na sekuncy a pak není potřeba v kódu přepočítávat $minutes * 60
- pak můžeš smazat větev [fix-cache-services](https://github.com/h4kuna/larastrict/tree/fix-cache-services-new)