### PR TITLE
PHPSTAN: Provide @template for JsonResource $resource for better access

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to an undefined property LaraStrict\\\\Http\\\\Resources\\\\JsonResource\\:\\:\\$preserveKeys\\.$#"
+			message: "#^Access to an undefined property LaraStrict\\\\Http\\\\Resources\\\\JsonResource\\<TResource\\>\\:\\:\\$preserveKeys\\.$#"
 			count: 1
 			path: src/Http/Resources/JsonResource.php
 

--- a/src/Http/Resources/JsonResource.php
+++ b/src/Http/Resources/JsonResource.php
@@ -6,20 +6,42 @@ namespace LaraStrict\Http\Resources;
 
 use Illuminate\Container\Container as LaravelContainer;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource as BaseJsonResource;
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Collection as SupportCollection;
 
+/**
+ * @template TResource
+ *
+ * @property TResource $resource
+ */
 abstract class JsonResource extends BaseJsonResource
 {
     private ?Container $container = null;
 
-    public function setContainer(Container $container): self
+    /**
+     * When created in your code base, it non-null, but Laravel for "collection" uses null.
+     *
+     * @param TResource $resource
+     */
+    public function __construct($resource)
+    {
+        parent::__construct($resource);
+    }
+
+    final public function setContainer(Container $container): static
     {
         $this->container = $container;
 
         return $this;
     }
 
+    /**
+     * @param array<TResource>|Collection<array-key, TResource>|SupportCollection<array-key, TResource>|Paginator<TResource>|AbstractPaginator<TResource> $resource
+     */
     public static function collection($resource): JsonResourceCollection
     {
         return tap(
@@ -34,7 +56,7 @@ abstract class JsonResource extends BaseJsonResource
         );
     }
 
-    protected function getContainer(): Container
+    final protected function getContainer(): Container
     {
         if ($this->container === null) {
             return LaravelContainer::getInstance();
@@ -49,7 +71,7 @@ abstract class JsonResource extends BaseJsonResource
      *
      * @return array<string|int, mixed>
      */
-    protected function resourceArray(Request $request, BaseJsonResource $resource): array
+    final protected function resourceArray(Request $request, BaseJsonResource $resource): array
     {
         if ($resource instanceof self || $resource instanceof JsonResourceCollection) {
             $resource->setContainer($this->getContainer());
@@ -66,7 +88,7 @@ abstract class JsonResource extends BaseJsonResource
      *
      * @return TInstance
      */
-    protected function instance(string $class, array $parameters = []): object
+    final protected function instance(string $class, array $parameters = []): object
     {
         return $this
             ->getContainer()

--- a/src/Http/Resources/MessageResource.php
+++ b/src/Http/Resources/MessageResource.php
@@ -7,16 +7,11 @@ namespace LaraStrict\Http\Resources;
 use LaraStrict\Http\Enums\HttpMessage;
 
 /**
- * @property HttpMessage|string $resource
+ * @extends JsonResource<HttpMessage|string>
  */
 class MessageResource extends JsonResource
 {
     public static $wrap = null;
-
-    public function __construct(HttpMessage|string|null $resource)
-    {
-        parent::__construct($resource);
-    }
 
     /**
      * @return array

--- a/tests/Feature/Http/Resources/LaraStrictResource.php
+++ b/tests/Feature/Http/Resources/LaraStrictResource.php
@@ -7,15 +7,10 @@ namespace Tests\LaraStrict\Feature\Http\Resources;
 use LaraStrict\Http\Resources\JsonResource;
 
 /**
- * @property TestEntity $resource
+ * @extends JsonResource<TestEntity>
  */
 class LaraStrictResource extends JsonResource
 {
-    public function __construct(?TestEntity $resource)
-    {
-        parent::__construct($resource);
-    }
-
     public function toArray($request): array
     {
         return [

--- a/tests/Unit/Http/Resources/ResourceArrayResource.php
+++ b/tests/Unit/Http/Resources/ResourceArrayResource.php
@@ -8,15 +8,10 @@ use Illuminate\Http\Resources\Json\JsonResource as BaseJsonResource;
 use LaraStrict\Http\Resources\JsonResource;
 
 /**
- * @property BaseJsonResource $resource
+ * @extends JsonResource<BaseJsonResource>
  */
 class ResourceArrayResource extends JsonResource
 {
-    public function __construct(?BaseJsonResource $resource)
-    {
-        parent::__construct($resource);
-    }
-
     /**
      * @return array<string, array<array<string, mixed>>>
      */


### PR DESCRIPTION
feat(PHPStan): Provide @template for JsonResource $resource for better type safe access

BREAKING CHANGE: PHPStan will now throw an error if you pass incorrect value to __construct or Resource::collection

- made setContainer/getContainer/resourceArray/instance final